### PR TITLE
SLING-10811 - Mark unresolved required capabilities as optional

### DIFF
--- a/src/main/java/org/apache/sling/scriptingbundle/plugin/bnd/BundledScriptsScannerPlugin.java
+++ b/src/main/java/org/apache/sling/scriptingbundle/plugin/bnd/BundledScriptsScannerPlugin.java
@@ -93,7 +93,7 @@ public class BundledScriptsScannerPlugin implements AnalyzerPlugin, Plugin {
         scriptEngineMappings = getConfiguredScriptEngineMappings();
         capabilities = Capabilities
                 .fromFileSystemTree(workDirectory, walkPath(workDirectory, includes, excludes), logger,
-                getConfiguredSearchPaths(), scriptEngineMappings);
+                getConfiguredSearchPaths(), scriptEngineMappings, getMissingRequirementsOptional());
         String providedCapabilitiesDefinition = capabilities.getProvidedCapabilitiesString();
         String requiredCapabilitiesDefinition = capabilities.getRequiredCapabilitiesString();
 
@@ -142,7 +142,6 @@ public class BundledScriptsScannerPlugin implements AnalyzerPlugin, Plugin {
     }
 
     private Set<PathMatcher> getConfiguredExcludes() {
-
         String excludesCSV = pluginProperties.get(Constants.BND_EXCLUDES);
         if (StringUtils.isNotEmpty(excludesCSV)) {
             return Collections.unmodifiableSet(Arrays.stream(excludesCSV.split(",")).map(String::trim)
@@ -187,6 +186,15 @@ public class BundledScriptsScannerPlugin implements AnalyzerPlugin, Plugin {
             return Collections.unmodifiableSet(Arrays.stream(searchPathsString.split(",")).map(String::trim).collect(Collectors.toSet()));
         }
         return Constants.DEFAULT_SEARCH_PATHS;
+    }
+
+    private boolean getMissingRequirementsOptional() {
+        String missingRequirementsOptionalString = pluginProperties.get(Constants.BND_MISSING_REQUIREMENTS_OPTIONAL);
+        if (missingRequirementsOptionalString != null) {
+            missingRequirementsOptionalString = missingRequirementsOptionalString.trim().toLowerCase();
+            return !"false".equals(missingRequirementsOptionalString);
+        }
+        return true;
     }
 
     private Stream<Path> walkPath(Path path, Set<PathMatcher> includes, Set<PathMatcher> excludes) throws IOException {

--- a/src/main/java/org/apache/sling/scriptingbundle/plugin/capability/RequiredResourceTypeCapability.java
+++ b/src/main/java/org/apache/sling/scriptingbundle/plugin/capability/RequiredResourceTypeCapability.java
@@ -78,7 +78,7 @@ public class RequiredResourceTypeCapability {
 
     @Override
     public String toString() {
-        return String.format("%s{resourceType=%s, versionRange=%s, isOptonal=%s}", this.getClass().getSimpleName(),
+        return String.format("%s{resourceType=%s, versionRange=%s, isOptional=%s}", this.getClass().getSimpleName(),
                 resourceType, versionRange, isOptional);
     }
 

--- a/src/main/java/org/apache/sling/scriptingbundle/plugin/maven/MetadataMojo.java
+++ b/src/main/java/org/apache/sling/scriptingbundle/plugin/maven/MetadataMojo.java
@@ -41,14 +41,10 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.io.DirectoryScanner;
-import org.apache.sling.api.servlets.ServletResolverConstants;
 import org.apache.sling.scriptingbundle.plugin.capability.Capabilities;
-import org.apache.sling.scriptingbundle.plugin.capability.RequiredResourceTypeCapability;
 import org.apache.sling.scriptingbundle.plugin.processor.Constants;
 import org.apache.sling.scriptingbundle.plugin.processor.Logger;
 import org.jetbrains.annotations.NotNull;
-import org.osgi.framework.Version;
-import org.osgi.framework.VersionRange;
 
 /**
  * The {@code metadata} goal will generate two Maven project properties, namely

--- a/src/main/java/org/apache/sling/scriptingbundle/plugin/maven/MetadataMojo.java
+++ b/src/main/java/org/apache/sling/scriptingbundle/plugin/maven/MetadataMojo.java
@@ -171,6 +171,14 @@ public class MetadataMojo extends AbstractMojo {
     @Parameter(property = "scriptingbundle.searchPaths")
     private Set<String> searchPaths;
 
+    /**
+     * When set to "true", the requirements which are not satisfied directly by this project will be marked as optional.
+     *
+     * @since 0.5.0
+     */
+    @Parameter(property = "scriptingbundle.missingRequirementsOptional", defaultValue = "true")
+    private boolean missingRequirementsOptional = true;
+
     private Capabilities capabilities;
 
     public void execute() {
@@ -221,18 +229,15 @@ public class MetadataMojo extends AbstractMojo {
                 scannerPaths.stream().map(workDirectory::resolve),
                 logger,
                 searchPaths,
-                scriptEngineMappings
+                scriptEngineMappings,
+                missingRequirementsOptional
             );
             String providedCapabilitiesDefinition = capabilities.getProvidedCapabilitiesString();
             String requiredCapabilitiesDefinition = capabilities.getRequiredCapabilitiesString();
-            String unresolvedRequiredCapabilitiesDefinition = getUnresolvedRequiredCapabilitiesString(capabilities);
             project.getProperties().put("org.apache.sling.scriptingbundle.maven.plugin." + org.osgi.framework.Constants.PROVIDE_CAPABILITY,
                     providedCapabilitiesDefinition);
             project.getProperties().put("org.apache.sling.scriptingbundle.maven.plugin." + org.osgi.framework.Constants.REQUIRE_CAPABILITY,
                     requiredCapabilitiesDefinition);
-            project.getProperties()
-                    .put("org.apache.sling.scriptingbundle.maven.plugin.Unresolved-" + org.osgi.framework.Constants.REQUIRE_CAPABILITY,
-                            unresolvedRequiredCapabilitiesDefinition);
         } catch (IOException e) {
             logger.error("Unable to generate working directory.", e);
         }
@@ -254,30 +259,6 @@ public class MetadataMojo extends AbstractMojo {
         }
         scanner.scan();
         return scanner;
-    }
-
-    @NotNull
-    private String getUnresolvedRequiredCapabilitiesString(Capabilities capabilities) {
-        StringBuilder builder = new StringBuilder();
-        int pcNum = capabilities.getUnresolvedRequiredResourceTypeCapabilities().size();
-        int pcIndex = 0;
-        for (RequiredResourceTypeCapability capability : capabilities.getUnresolvedRequiredResourceTypeCapabilities()) {
-            builder.append(Constants.CAPABILITY_NS).append(";");
-            builder.append(ServletResolverConstants.SLING_SERVLET_RESOURCE_TYPES).append("=").append(capability.getResourceType());
-            VersionRange versionRange = capability.getVersionRange();
-            if (versionRange != null) {
-                Version left = versionRange.getLeft();
-                if (versionRange.getLeftType() == VersionRange.LEFT_OPEN) {
-                    left = new Version(left.getMajor(), left.getMinor(), left.getMicro() + 1);
-                }
-                builder.append(";").append(Constants.CAPABILITY_VERSION_AT).append("=").append(left);
-            }
-            if (pcIndex < pcNum - 1) {
-                builder.append(",");
-            }
-            pcIndex++;
-        }
-        return builder.toString();
     }
 
     Capabilities getCapabilities() {

--- a/src/main/java/org/apache/sling/scriptingbundle/plugin/processor/Constants.java
+++ b/src/main/java/org/apache/sling/scriptingbundle/plugin/processor/Constants.java
@@ -52,6 +52,7 @@ public final class Constants {
     public static final String BND_INCLUDES = "includes";
     public static final String BND_SCRIPT_ENGINE_MAPPINGS = "scriptEngineMappings";
     public static final String BND_SEARCH_PATHS = "searchPaths";
+    public static final String BND_MISSING_REQUIREMENTS_OPTIONAL = "missingRequirementsOptional";
 
     public static final Map<String, String> DEFAULT_EXTENSION_TO_SCRIPT_ENGINE_MAPPING;
     public static final Set<String> DEFAULT_SEARCH_PATHS;

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -36,6 +36,11 @@ page. In addition to the normal way of structuring scripts in the file tree, the
      is defined as a package name, the resource type label will be the last subpackage (i.e. for `com.mydomain.components.image`, the
      resource type label will be `image`).
 
+Starting with version 0.5.0, the plugin will mark the requirements which are not satisfied by the analysed project as optional; classpath
+dependencies are not checked for provided capabilities. If you want to generate mandatory requirements, set the `missingRequirementsOptional`
+flag to `false`.
+
+
 $h3 Defining scripts
 As an example, let's assume the following layout:
 ```

--- a/src/test/resources/project-4/bnd.bnd
+++ b/src/test/resources/project-4/bnd.bnd
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+-plugin:    org.apache.sling.scriptingbundle.plugin.bnd.BundledScriptsScannerPlugin; \
+            missingRequirementsOptional=false

--- a/src/test/resources/project-4/pom.xml
+++ b/src/test/resources/project-4/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.sling</groupId>
+    <artifactId>scriptingbundle-maven-plugin-project-1</artifactId>
+    <version>0.0.1</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>scriptingbundle-maven-plugin</artifactId>
+                <configuration>
+                    <missingRequirementsOptional>false</missingRequirementsOptional>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>metadata</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/project-4/src/main/scripts/apps/components/test/requires
+++ b/src/test/resources/project-4/src/main/scripts/apps/components/test/requires
@@ -1,0 +1,1 @@
+components/testhelper

--- a/src/test/resources/project-4/src/main/scripts/apps/components/test/test.html
+++ b/src/test/resources/project-4/src/main/scripts/apps/components/test/test.html
@@ -1,0 +1,18 @@
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->


### PR DESCRIPTION
* required capabilities which are not satisfied by the current project are marked as optional; a flag can disable this behaviour, making these required capabilities mandatory